### PR TITLE
Don't send activity reminders for disabled activities

### DIFF
--- a/karrot/activities/tasks.py
+++ b/karrot/activities/tasks.py
@@ -34,6 +34,9 @@ def activity_reminder(participant_id):
         return
 
     activity = participant.activity
+    if activity.is_disabled:
+        return
+
     user = participant.user
     language = user.language
     tz = activity.group.timezone

--- a/karrot/activities/tests/test_tasks.py
+++ b/karrot/activities/tests/test_tasks.py
@@ -62,6 +62,14 @@ class TestActivityReminderTask(TestCase):
             kwargs['fcm_options']['message_body'],
         )
 
+    def test_does_not_send_for_disabled_activity(self, notify_subscribers_by_device):
+        self.activity.is_disabled = True
+        self.activity.save()
+        participant = ActivityParticipant.objects.create(user=self.user, activity=self.activity)
+        notify_subscribers_by_device.reset_mock()
+        tasks.activity_reminder.call_local(participant.id)
+        self.assertEqual(notify_subscribers_by_device.call_count, 0)
+
 
 class TestActivityNotificationTask(APITestCase):
     @classmethod

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # Translations template for PROJECT.
-# Copyright (C) 2021 ORGANIZATION
+# Copyright (C) 2022 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #
 #, fuzzy
 msgid ""
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Must pass start value"
 msgstr ""
 
-#: karrot/activities/tasks.py:68
+#: karrot/activities/tasks.py:71
 #, python-format
 msgid "Upcoming %(activity_type)s"
 msgstr ""


### PR DESCRIPTION
Fixes https://github.com/karrot-dev/karrot-frontend/issues/2480

It just checks the disabled property at the moment it _would_ send a reminder.

It could also delete the scheduled task, but seems OK like this :)