### PR TITLE
Add more activity filters and pagination options

### DIFF
--- a/karrot/activities/api.py
+++ b/karrot/activities/api.py
@@ -203,6 +203,7 @@ class ActivityPagination(CursorPagination):
     Could be reduced and add pagination handling in frontend when speed becomes an issue"""
     # TODO: we *really* need to add that pagination to the frontend! https://github.com/karrot-dev/karrot-frontend/issues/2388
     page_size = 1200
+    page_size_query_param = 'page_size'
     ordering = 'date'
 
 

--- a/karrot/activities/filters.py
+++ b/karrot/activities/filters.py
@@ -31,10 +31,21 @@ class ActivitiesFilter(filters.FilterSet):
     date = ISODateTimeRangeFromToRangeFilter(field_name='date', lookup_expr='overlap')
     feedback_possible = filters.BooleanFilter(method='filter_feedback_possible')
     joined = filters.BooleanFilter(method='filter_joined')
+    activity_type = filters.NumberFilter(field_name='activity_type')
+    slots = filters.ChoiceFilter(method='filter_slots', choices=[(val, val) for val in ('free', 'empty', 'joined')])
 
     class Meta:
         model = Activity
-        fields = ['place', 'group', 'date', 'series', 'feedback_possible', 'joined']
+        fields = [
+            'place',
+            'group',
+            'date',
+            'series',
+            'feedback_possible',
+            'joined',
+            'activity_type',
+            'slots',
+        ]
 
     def filter_feedback_possible(self, qs, name, value):
         if value is True:
@@ -46,6 +57,15 @@ class ActivitiesFilter(filters.FilterSet):
             return qs.filter(participants=self.request.user)
         elif value is False:
             return qs.filter(~Q(participants=self.request.user))
+        return qs
+
+    def filter_slots(self, qs, name, value):
+        if value == 'free':
+            return qs.with_free_slots()
+        elif value == 'empty':
+            return qs.empty()
+        elif value == 'joined':
+            return qs.with_participant(self.request.user)
         return qs
 
 

--- a/karrot/activities/models.py
+++ b/karrot/activities/models.py
@@ -219,8 +219,21 @@ class ActivityQuerySet(models.QuerySet):
 
     def done_not_full(self):
         return self.exclude_disabled() \
-            .annotate(participant_count=Count('participants')) \
-            .filter(date__startswith__lt=timezone.now(), participant_count__lt=F('max_participants'))
+            .annotate_num_participants() \
+            .filter(date__startswith__lt=timezone.now(), num_participants__lt=F('max_participants'))
+
+    def with_free_slots(self):
+        return self.exclude_disabled() \
+            .annotate_num_participants() \
+            .filter(num_participants__lt=F('max_participants'))
+
+    def empty(self):
+        return self.exclude_disabled() \
+            .annotate_num_participants() \
+            .filter(num_participants=0)
+
+    def with_participant(self, user):
+        return self.filter(participants=user)
 
     def upcoming(self):
         return self.filter(date__startswith__gt=timezone.now())


### PR DESCRIPTION
As part of the work for frontend activity pagination / filtering, using vue-query, the backend needs some updates. This should be backwards compatible with current frontend as it only adds _more_ options, and does not take any away.

For activities, you can now:
- pass in a `page_size` param to say how many results per page (default is 1200, as current frontend has no pagination)
- pass in values the filters that we used to do in front-end only, so:
  - `activity_type`
  - `slots` (including a new "joined" option, that does same as "joined" filter param...)

This would be useful to review/merge as soon as possible, as until then I can't see how well the new frontend is doing in realworld examples...