### PR TITLE
Add more bootstrap data and other tweaks

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -389,6 +389,11 @@ HOSTNAME = options['SITE_URL']
 SITE_NAME = options['SITE_NAME']
 MEDIA_ROOT = options['FILE_UPLOAD_DIR']
 
+if is_dev:
+    # in prod daphne (and I guess uvicorn) handle this
+    # but if using https during local dev we need this
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 if options['FILE_UPLOAD_PERMISSIONS']:
     FILE_UPLOAD_PERMISSIONS = int(options['FILE_UPLOAD_PERMISSIONS'], 8)  # e.g. 0o640
 

--- a/karrot/activities/api.py
+++ b/karrot/activities/api.py
@@ -228,7 +228,10 @@ class ActivityViewSet(
     pagination_class = ActivityPagination
 
     def get_queryset(self):
-        qs = self.queryset.filter(place__group__members=self.request.user, place__status=PlaceStatus.ACTIVE.value)
+        qs = self.queryset.filter(place__group__members=self.request.user)
+        if self.action == 'list':
+            # only filter list by active places, as we need to get activities for not active places
+            qs = qs.filter(place__status=PlaceStatus.ACTIVE.value)
         if self.action in ('retrieve', 'list'):
             # because we have participants field in the serializer
             # only prefetch on read_only actions, otherwise there are caching problems when participants get added

--- a/karrot/activities/tests/test_activities_api.py
+++ b/karrot/activities/tests/test_activities_api.py
@@ -529,7 +529,7 @@ class TestActivitiesAPI(APITestCase, ExtractPaginationMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
 
-class TestActivitiesListAPI(APITestCase, ExtractPaginationMixin):
+class TestActivitiesAPIWithInactivePlaces(APITestCase, ExtractPaginationMixin):
     def setUp(self):
         self.url = '/api/activities/'
 
@@ -554,3 +554,9 @@ class TestActivitiesListAPI(APITestCase, ExtractPaginationMixin):
         response = self.get_results(self.url, {'place': self.inactive_place.id})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
+
+    def test_get_activity_for_inactive_place(self):
+        self.client.force_login(user=self.member)
+        activity = self.inactive_place.activities.first()
+        response = self.client.get(f'/api/activities/{activity.id}/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/karrot/bootstrap/api.py
+++ b/karrot/bootstrap/api.py
@@ -1,10 +1,15 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.db.models import Q
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from config.options import get_git_rev
+from karrot.activities.models import ActivityType
 from karrot.bootstrap.serializers import BootstrapSerializer, ConfigSerializer
 from karrot.groups.models import Group
+from karrot.places.models import Place
+from karrot.status.helpers import status_data
 from karrot.utils.geoip import geoip_is_available, get_client_ip, ip_to_city
 
 BACKEND_REVISION = get_git_rev()
@@ -38,30 +43,72 @@ class BootstrapViewSet(GenericViewSet):
     serializer_class = BootstrapSerializer  # for OpenAPI generation with drf-spectacular
 
     def list(self, request, *args, **kwargs):
+        fields = request.query_params.get('fields', 'server,config,geoip,user,groups').split(',')
         user = request.user
-        geo_data = None
 
+        data = {
+            'server': {
+                'revision': BACKEND_REVISION,
+            } if 'server' in fields else None,
+            'config': get_config_data() if 'config' in fields else None,
+            'geoip': self.get_geoip(request) if 'geoip' in fields else None,
+            'groups': self.get_groups(user) if 'groups' in fields else None,
+        }
+
+        if user.is_authenticated:
+            data.update({
+                'user': user if 'user' in fields else None,
+                'places': self.get_places(user) if 'places' in fields else None,
+                'users': self.get_users(user) if 'users' in fields else None,
+                'status': self.get_status(user) if 'status' in fields else None,
+                'activity_types': self.get_activity_types(user) if 'activity_types' in fields else None,
+            })
+
+        # only keep fields we want (others should be None anyway...)
+        data = {key: val for key, val in data.items() if key in fields}
+        serializer = BootstrapSerializer(data, context=self.get_serializer_context())
+        return Response(serializer.data)
+
+    @staticmethod
+    def get_geoip(request):
         if geoip_is_available():
             client_ip = get_client_ip(request)
             if client_ip:
                 city = ip_to_city(client_ip)
                 if city:
-                    geo_data = {
+                    return {
                         'lat': city.get('latitude', None),
                         'lng': city.get('longitude', None),
                         'country_code': city.get('country_code', None),
                         'timezone': city.get('time_zone', None),
                     }
 
-        data = {
-            'server': {
-                'revision': BACKEND_REVISION,
-            },
-            'config': get_config_data(),
-            'user': user if user.is_authenticated else None,
-            'geoip': geo_data,
-            'groups': Group.objects.annotate_member_count().annotate_is_user_member(user),
-        }
+    @staticmethod
+    def get_groups(user):
+        return Group.objects.annotate_member_count().annotate_is_user_member(user)
 
-        serializer = BootstrapSerializer(data, context=self.get_serializer_context())
-        return Response(serializer.data)
+    @staticmethod
+    def get_users(user):
+        is_member_of_group = Q(groups__in=user.groups.all())
+
+        is_self = Q(id=user.id)
+
+        groups = user.groups.all()
+        is_applicant_of_group = Q(application__group__in=groups)
+
+        return get_user_model().objects \
+            .active() \
+            .filter(is_member_of_group | is_applicant_of_group | is_self) \
+            .distinct()
+
+    @staticmethod
+    def get_status(user):
+        return status_data(user)
+
+    @staticmethod
+    def get_places(user):
+        return Place.objects.filter(group__members=user).prefetch_related('subscribers')
+
+    @staticmethod
+    def get_activity_types(user):
+        return ActivityType.objects.filter(group__members=user)

--- a/karrot/bootstrap/serializers.py
+++ b/karrot/bootstrap/serializers.py
@@ -1,7 +1,11 @@
 from rest_framework import serializers
 
+from karrot.activities.serializers import ActivityTypeSerializer
 from karrot.groups.serializers import GroupPreviewSerializer
+from karrot.places.serializers import PlaceSerializer
+from karrot.status.helpers import StatusSerializer
 from karrot.userauth.serializers import AuthUserSerializer
+from karrot.users.serializers import UserSerializer
 
 
 class ServerInfoSerializer(serializers.Serializer):
@@ -33,8 +37,15 @@ class ConfigSerializer(serializers.Serializer):
 
 
 class BootstrapSerializer(serializers.Serializer):
-    server = ServerInfoSerializer()
-    config = ConfigSerializer()
-    user = AuthUserSerializer()
-    geoip = GeoSerializer()
-    groups = GroupPreviewSerializer(many=True)
+    # always available
+    server = ServerInfoSerializer(required=False)
+    config = ConfigSerializer(required=False)
+    geoip = GeoSerializer(required=False)
+    groups = GroupPreviewSerializer(many=True, required=False)
+
+    # require authenticated user
+    user = AuthUserSerializer(required=False)
+    places = PlaceSerializer(many=True, required=False)
+    users = UserSerializer(many=True, required=False)
+    status = StatusSerializer(required=False)
+    activity_types = ActivityTypeSerializer(many=True, required=False)

--- a/karrot/bootstrap/tests/test_api.py
+++ b/karrot/bootstrap/tests/test_api.py
@@ -120,3 +120,21 @@ class TestBootstrapAPI(APITestCase):
             response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['user']['id'], self.user.id)
+
+    def test_can_specify_selected_fields(self):
+        self.client.force_login(user=self.user)
+        response = self.client.get(self.url, {'fields': 'places,activity_types'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(list(response.data.keys()), ['places', 'activity_types'])
+
+    def test_can_specify_all_fields(self):
+        self.client.force_login(user=self.user)
+        fields = 'server,config,geoip,user,groups,places,users,status,activity_types'
+        response = self.client.get(self.url, {'fields': fields})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(sorted(list(response.data.keys())), sorted(fields.split(',')))
+
+    def test_complains_for_invalid_fields(self):
+        self.client.force_login(user=self.user)
+        response = self.client.get(self.url, {'fields': 'notafield,orthisone'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/karrot/issues/api.py
+++ b/karrot/issues/api.py
@@ -9,6 +9,7 @@ from rest_framework.throttling import UserRateThrottle
 from rest_framework.viewsets import GenericViewSet
 
 from karrot.conversations.api import RetrieveConversationMixin
+from karrot.issues.filters import IssuesFilter
 from karrot.issues.models import Issue
 from karrot.issues.serializers import IssueSerializer, VoteSerializer
 
@@ -40,7 +41,7 @@ class IssuesViewSet(
 ):
     queryset = Issue.objects
     filter_backends = (filters.DjangoFilterBackend, )
-    filterset_fields = ('group', 'status')
+    filterset_class = IssuesFilter
     serializer_class = IssueSerializer
     permission_classes = (IsAuthenticated, )
     pagination_class = IssuePagination
@@ -91,7 +92,4 @@ class IssuesViewSet(
         if request.method == 'DELETE':
             deleted = voting.delete_votes(user=request.user)
 
-            return Response(
-                data={},
-                status=status.HTTP_204_NO_CONTENT if deleted else status.HTTP_404_NOT_FOUND,
-            )
+            return Response(status=status.HTTP_204_NO_CONTENT if deleted else status.HTTP_404_NOT_FOUND)

--- a/karrot/issues/filters.py
+++ b/karrot/issues/filters.py
@@ -1,0 +1,16 @@
+from django_filters import ModelChoiceFilter, MultipleChoiceFilter, rest_framework as filters
+
+from karrot.issues.models import Issue, IssueStatus
+
+
+def groups_queryset(request):
+    return request.user.groups.all()
+
+
+class IssuesFilter(filters.FilterSet):
+    group = ModelChoiceFilter(queryset=groups_queryset)
+    status = MultipleChoiceFilter(choices=[(status.value, status.value) for status in IssueStatus])
+
+    class Meta:
+        model = Issue
+        fields = ['group', 'status']

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -588,7 +588,7 @@ msgstr ""
 msgid "Follow the invitation"
 msgstr ""
 
-#: karrot/issues/api.py:17
+#: karrot/issues/api.py:18
 msgid "Can only modify vote for ongoing issues"
 msgstr ""
 
@@ -751,6 +751,10 @@ msgstr ""
 
 #: karrot/places/serializers.py:227
 msgid "You are already subscribed to this place"
+msgstr ""
+
+#: karrot/subscriptions/receivers.py:738
+msgid "Push notifications are enabled!"
 msgstr ""
 
 #: karrot/userauth/api.py:98 karrot/userauth/serializers.py:102

--- a/karrot/subscriptions/fcm.py
+++ b/karrot/subscriptions/fcm.py
@@ -43,7 +43,8 @@ def _notify_multiple_devices(**kwargs):
     """
 
     if fcm is None:
-        return 0, 0
+        print('tried to send fcm messages, but fcm is not available')
+        return [], []
 
     response = fcm.notify_multiple_devices(**kwargs)
     sentry_sdk.set_context('fcm_response', response)
@@ -74,6 +75,7 @@ def _notify_multiple_devices(**kwargs):
     # tell Sentry if there were errors
     if len(failure_indices) > 0:
         sentry_sdk.capture_message('FCM error while sending', extras=response)
+        logger.error(response)
         logger.warning(
             'FCM error while sending: {} tokens successful, {} failed, {} removed from database'.format(
                 len(success_indices), len(failure_indices), len(cleanup_tokens)

--- a/karrot/subscriptions/receivers.py
+++ b/karrot/subscriptions/receivers.py
@@ -377,6 +377,7 @@ def place_subscription_updated(sender, instance, **kwargs):
 
 # Activities
 @receiver(post_save, sender=Activity)
+@on_transaction_commit
 def send_activity_updates(sender, instance, **kwargs):
     activity = instance
     if activity.is_done:
@@ -390,6 +391,7 @@ def send_activity_updates(sender, instance, **kwargs):
 
 
 @receiver(pre_delete, sender=Activity)
+@on_transaction_commit
 def send_activity_deleted(sender, instance, **kwargs):
     activity = instance
     payload = ActivitySerializer(activity).data
@@ -400,6 +402,7 @@ def send_activity_deleted(sender, instance, **kwargs):
 
 @receiver(post_save, sender=ActivityParticipant)
 @receiver(post_delete, sender=ActivityParticipant)
+@on_transaction_commit
 def send_activity_participant_updates(sender, instance, **kwargs):
     activity = instance.activity
     payload = ActivitySerializer(activity).data

--- a/karrot/subscriptions/receivers.py
+++ b/karrot/subscriptions/receivers.py
@@ -7,6 +7,7 @@ from django.contrib.auth import user_logged_out
 from django.db.models import Q
 from django.db.models.signals import post_save, pre_delete, post_delete
 from django.dispatch import receiver
+from django.utils.translation import gettext as _
 
 from karrot.applications.models import Application
 from karrot.applications.serializers import ApplicationSerializer
@@ -38,7 +39,8 @@ from karrot.places.serializers import PlaceSerializer
 from karrot.status.helpers import unseen_notification_count, unread_conversations, pending_applications, \
     get_feedback_possible
 from karrot.subscriptions import tasks
-from karrot.subscriptions.models import ChannelSubscription
+from karrot.subscriptions.models import ChannelSubscription, PushSubscription
+from karrot.subscriptions.tasks import notify_subscribers_by_device
 from karrot.subscriptions.utils import send_in_channel, MockRequest
 from karrot.userauth.serializers import AuthUserSerializer
 from karrot.users.serializers import UserSerializer
@@ -724,3 +726,14 @@ def send_feedback_possible_count(user):
 
     for subscription in ChannelSubscription.objects.recent().filter(user=user):
         send_in_channel(subscription.reply_channel, topic='status', payload=payload)
+
+
+@receiver(post_save, sender=PushSubscription)
+def push_subscription_created(sender, instance, created, **kwargs):
+    if not created:
+        return
+    subscription = instance
+    # send them a welcome push message!
+    notify_subscribers_by_device([subscription], fcm_options={
+        'message_title': _('Push notifications are enabled!'),
+    })

--- a/karrot/subscriptions/tasks.py
+++ b/karrot/subscriptions/tasks.py
@@ -184,7 +184,7 @@ def notify_subscribers_by_device(subscriptions, *, click_action=None, fcm_option
     android_subscriptions = [s for s in subscriptions if s.platform == PushSubscriptionPlatform.ANDROID.value]
     web_subscriptions = [s for s in subscriptions if s.platform == PushSubscriptionPlatform.WEB.value]
 
-    def android_click_action_options():
+    def get_android_click_action_options():
         if not click_action:
             return {}
         return {
@@ -196,7 +196,7 @@ def notify_subscribers_by_device(subscriptions, *, click_action=None, fcm_option
             },
         }
 
-    def web_click_action_options():
+    def get_web_click_action_options():
         if not click_action:
             return {}
         return {
@@ -207,7 +207,7 @@ def notify_subscribers_by_device(subscriptions, *, click_action=None, fcm_option
         notify_subscribers(
             subscriptions=android_subscriptions, fcm_options={
                 **fcm_options,
-                **android_click_action_options,
+                **get_android_click_action_options(),
             }
         )
 
@@ -217,7 +217,7 @@ def notify_subscribers_by_device(subscriptions, *, click_action=None, fcm_option
         notify_subscribers(
             subscriptions=web_subscriptions, fcm_options={
                 **fcm_options,
-                **web_click_action_options(),
+                **get_web_click_action_options(),
             }
         )
 

--- a/karrot/subscriptions/tests/test_fcm.py
+++ b/karrot/subscriptions/tests/test_fcm.py
@@ -3,7 +3,9 @@ from importlib import reload
 from unittest.mock import patch
 
 import requests_mock
+from django.db.models.signals import post_save
 from django.test import TestCase
+from factory.django import mute_signals
 
 import karrot.subscriptions.fcm
 from karrot.subscriptions import fcm
@@ -53,7 +55,7 @@ class FCMTests(TestCase):
         _notify_multiple_devices(registration_ids=['mytoken'])
 
     def test_removes_invalid_subscriptions(self, m):
-        with logger_warning_mock() as warning_mock, override_fcm_key('something'):
+        with mute_signals(post_save), logger_warning_mock() as warning_mock, override_fcm_key('something'):
             valid = PushSubscriptionFactory()
             invalid = PushSubscriptionFactory()
             invalid2 = PushSubscriptionFactory()
@@ -93,8 +95,9 @@ class FCMNotifySubscribersTests(TestCase):
     @patch('karrot.subscriptions.stats.write_points')
     @patch('karrot.subscriptions.fcm._notify_multiple_devices')
     def test_notify_subscribers(self, _notify_multiple_devices, write_points):
-        web_subscriptions = [PushSubscriptionFactory(platform='web') for _ in range(3)]
-        android_subscriptions = [PushSubscriptionFactory(platform='android') for _ in range(5)]
+        with mute_signals(post_save):
+            web_subscriptions = [PushSubscriptionFactory(platform='web') for _ in range(3)]
+            android_subscriptions = [PushSubscriptionFactory(platform='android') for _ in range(5)]
         subscriptions = web_subscriptions + android_subscriptions
 
         write_points.reset_mock()
@@ -138,8 +141,9 @@ class FCMNotifySubscribersTests(TestCase):
     @patch('karrot.subscriptions.stats.write_points')
     @patch('karrot.subscriptions.fcm.fcm')
     def test_prevent_cleanup_and_stats_if_result_count_does_not_match(self, mock_fcm, write_points):
-        # we give it one subscription, and it gives us two responses!?
-        subscription = PushSubscriptionFactory()
+        with mute_signals(post_save):
+            # we give it one subscription, and it gives us two responses!?
+            subscription = PushSubscriptionFactory()
 
         mock_fcm.notify_multiple_devices.return_value = {
             'results': [

--- a/karrot/subscriptions/tests/test_fcm.py
+++ b/karrot/subscriptions/tests/test_fcm.py
@@ -86,7 +86,7 @@ class FCMTests(TestCase):
         with logger_warning_mock() as warning_mock, override_fcm_key():
             warning_mock.assert_called_with('Please configure FCM_SERVER_KEY in your settings to use push messaging')
             result = _notify_multiple_devices(registration_ids=['mytoken'])
-            self.assertEqual(result, (0, 0))
+            self.assertEqual(result, ([], []))
 
 
 class FCMNotifySubscribersTests(TestCase):

--- a/karrot/subscriptions/tests/test_receivers.py
+++ b/karrot/subscriptions/tests/test_receivers.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 
@@ -123,7 +123,7 @@ class WSClient:
         }
 
 
-class WSTestCase(TestCase):
+class WSTransactionTestCase(TransactionTestCase):
     def setUp(self):
         super().setUp()
         self.send_in_channel_patcher = patch('karrot.subscriptions.receivers.send_in_channel')
@@ -134,6 +134,10 @@ class WSTestCase(TestCase):
         client = WSClient(self.send_in_channel_mock)
         client.connect_as(user)
         return client
+
+
+class WSTestCase(WSTransactionTestCase, TestCase):
+    pass
 
 
 class ConversationReceiverTests(WSTestCase):
@@ -752,7 +756,7 @@ class PlaceReceiverTests(WSTestCase):
         self.assertEqual(len(client.messages), 1)
 
 
-class ActivityReceiverTests(WSTestCase):
+class ActivityReceiverTests(WSTransactionTestCase):
     def setUp(self):
         super().setUp()
         self.member = UserFactory()

--- a/karrot/subscriptions/tests/test_receivers.py
+++ b/karrot/subscriptions/tests/test_receivers.py
@@ -1102,6 +1102,25 @@ class IssueReceiverTest(WSTestCase):
 
 
 @patch('karrot.subscriptions.tasks.notify_subscribers')
+class PushWelcomeMessageTests(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+
+    def test_sends_a_welcome_push_message(self, notify_subscribers):
+        token = faker.uuid4()
+        subscription = PushSubscription.objects.create(
+            user=self.user,
+            token=token,
+            platform=PushSubscriptionPlatform.ANDROID.value,
+        )
+        self.assertEqual(notify_subscribers.call_count, 1)
+
+        kwargs = notify_subscribers.call_args_list[0][1]
+        self.assertEqual(list(kwargs['subscriptions']), [subscription])
+        self.assertEqual(kwargs['fcm_options']['message_title'], 'Push notifications are enabled!')
+
+
+@patch('karrot.subscriptions.tasks.notify_subscribers')
 class ReceiverPushTests(TestCase):
     def setUp(self):
         self.user = UserFactory()


### PR DESCRIPTION
This adds more stuff into the boostrap endpoint, with a new "fields" parameter so the frontend can choose which components to receive. This is to allow it to evolve over time, rather than always get everything. When omitting the parameter it'll default to what it did before there was a parameter option.

Other tweaks:
- allow to get activities individually (i.e. not-list actions) from inactive places, this was needed to fetch the activity for activity chats where the place is now inactive...
- only send activity update websocket events after transaction complete (otherwise refetches triggered from the updates will have previous data)
- enable x-forwarded-for headers in local dev (so if using https during dev, we can get https:// proto in image urls)
- add "push notifications are enabled!" push message, which helps to see if it actually worked...
- allow filtering issues by multiple statuses at once (useful for getting "not-ongoing" ones...