### PR TITLE
Fix duplicate activity display

### DIFF
--- a/karrot/activities/models.py
+++ b/karrot/activities/models.py
@@ -211,7 +211,8 @@ class ActivityQuerySet(models.QuerySet):
                 .filter(membership__roles__contains=[F('role')])
 
         activities = self.exclude_disabled() \
-            .filter(participant_types__in=participant_types_with_free_slots)
+            .filter(participant_types__in=participant_types_with_free_slots) \
+            .distinct()
 
         return activities
 

--- a/karrot/locale/en/LC_MESSAGES/django.po
+++ b/karrot/locale/en/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # Translations template for PROJECT.
-# Copyright (C) 2022 ORGANIZATION
+# Copyright (C) 2023 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 #, fuzzy
 msgid ""


### PR DESCRIPTION
Fixes https://github.com/karrot-dev/karrot-frontend/issues/2611

Was caused when an activity had multiple participant types with free slots and you filter by "with free slots", as it first queries the participant types then got the activities with using `.distinct()`.