### PR TITLE
Turn off on demand image creation

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -334,11 +334,8 @@ PREVIEW_SIZE = 1600
 THUMBNAIL_SIZE = 200
 
 VERSATILEIMAGEFIELD_SETTINGS = {
-    # TODO: implement the proper way of auto creating images
-    # See https://django-versatileimagefield.readthedocs.io/en/latest/improving_performance.html#auto-creating-sets-of-images-on-post-save
-    # I previously had it locally set to False to not get exceptions for missing images
-    # See https://github.com/respondcreate/django-versatileimagefield/issues/24#issuecomment-160674807
-    'create_images_on_demand': True,
+    # need to always create them on save
+    'create_images_on_demand': False,
 }
 
 VERSATILEIMAGE_PREVIEW = f'thumbnail__{PREVIEW_SIZE}x{PREVIEW_SIZE}'

--- a/karrot/activities/models.py
+++ b/karrot/activities/models.py
@@ -13,6 +13,7 @@ from django.db.models import Count, DurationField, F, FilteredRelation, Q, Sum, 
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from versatileimagefield.fields import VersatileImageField
+from versatileimagefield.image_warmer import VersatileImageFieldWarmer
 
 from karrot.base.base_models import BaseModel, CustomDateTimeTZRange, CustomDateTimeRangeField, UpdatedAtMixin
 from karrot.conversations.models import ConversationMixin
@@ -547,3 +548,12 @@ class ICSAuthToken(NicelyFormattedModel):
     token = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.OneToOneField('users.User', on_delete=models.CASCADE)
     created_at = models.DateTimeField(default=timezone.now)
+
+
+def create_activity_banner_image_warmer(instance_or_queryset, *, verbose=False):
+    return VersatileImageFieldWarmer(
+        instance_or_queryset=instance_or_queryset,
+        rendition_key_set='activity_banner_image',
+        image_attr='banner_image',
+        verbose=verbose,
+    )

--- a/karrot/activities/receivers.py
+++ b/karrot/activities/receivers.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from huey.contrib.djhuey import revoke_by_id
 
 from karrot.activities import stats, tasks
-from karrot.activities.models import Activity, Feedback, ActivityParticipant
+from karrot.activities.models import Activity, Feedback, ActivityParticipant, create_activity_banner_image_warmer
 from karrot.conversations.models import Conversation
 from karrot.groups.models import GroupMembership
 from karrot.places.models import Place, PlaceStatus
@@ -105,3 +105,9 @@ def update_activity_series_when_place_changes(sender, instance, **kwargs):
     if place_became_active or weeks_in_advance_changed:
         for series in place.series.all():
             series.update_activities()
+
+
+@receiver(post_save, sender=Activity)
+def warm_activity_banner_image(sender, instance, **kwargs):
+    if instance.banner_image:
+        create_activity_banner_image_warmer(instance).warm()

--- a/karrot/conversations/models.py
+++ b/karrot/conversations/models.py
@@ -11,6 +11,7 @@ from django.db.models import Count, F, IntegerField, Q
 from django.db.models.manager import BaseManager
 from django.utils import timezone
 from versatileimagefield.fields import VersatileImageField
+from versatileimagefield.image_warmer import VersatileImageFieldWarmer
 
 from config.settings import USERNAME_MENTION_RE
 from karrot.base.base_models import BaseModel, UpdatedAtMixin
@@ -543,3 +544,12 @@ class ConversationMessageAttachment(BaseModel):
                         )
             except UnidentifiedImageError:
                 pass
+
+
+def create_conversation_message_image_warmer(instance_or_queryset, *, verbose=False):
+    return VersatileImageFieldWarmer(
+        instance_or_queryset=instance_or_queryset,
+        rendition_key_set='conversation_message_image',
+        image_attr='image',
+        verbose=verbose,
+    )

--- a/karrot/groups/models.py
+++ b/karrot/groups/models.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from dirtyfields import DirtyFieldsMixin
 
+from versatileimagefield.image_warmer import VersatileImageFieldWarmer
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
@@ -346,3 +347,12 @@ class Role(BaseModel):
 
     class Meta:
         unique_together = (('name', 'group'))
+
+
+def create_group_photo_warmer(instance_or_queryset, *, verbose=False):
+    return VersatileImageFieldWarmer(
+        instance_or_queryset=instance_or_queryset,
+        rendition_key_set='group_logo',
+        image_attr='photo',
+        verbose=verbose,
+    )

--- a/karrot/groups/receivers.py
+++ b/karrot/groups/receivers.py
@@ -9,7 +9,7 @@ from karrot.conversations.models import Conversation
 from karrot.groups import roles, stats
 from karrot.groups.emails import prepare_user_became_editor_email, prepare_user_lost_editor_role_email, \
     prepare_user_got_role_email
-from karrot.groups.models import Group, GroupMembership, Trust
+from karrot.groups.models import Group, GroupMembership, Trust, create_group_photo_warmer
 from karrot.groups.roles import GROUP_EDITOR
 from karrot.history.models import History, HistoryTypus
 from karrot.utils import frontend_urls
@@ -174,3 +174,9 @@ def notify_chat_on_group_creation(sender, instance, created, **kwargs):
 
     response = requests.post(webhook_url, data=json.dumps(message_data), headers={'Content-Type': 'application/json'})
     response.raise_for_status()
+
+
+@receiver(post_save, sender=Group)
+def warm_group_photo(sender, instance, **kwargs):
+    if instance.photo:
+        create_group_photo_warmer(instance).warm()

--- a/karrot/management/commands/warm_images.py
+++ b/karrot/management/commands/warm_images.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+from django.db.models import Q
+
+from karrot.activities.models import Activity, create_activity_banner_image_warmer
+from karrot.conversations.models import ConversationMessageImage, create_conversation_message_image_warmer
+from karrot.groups.models import create_group_photo_warmer, Group
+from karrot.offers.models import create_offer_image_warmer, OfferImage
+from karrot.userauth.models import create_user_photo_warmer
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        print('Warming user photos')
+        succeeded, failed = create_user_photo_warmer(
+            get_user_model().objects.filter(~Q(photo='')),
+            verbose=True,
+        ).warm()
+        print('succeeded', succeeded, 'failed', len(failed))
+
+        print('Warming group photos')
+        succeeded, failed = create_group_photo_warmer(
+            Group.objects.filter(~Q(photo='')),
+            verbose=True,
+        ).warm()
+        print('succeeded', succeeded, 'failed', len(failed))
+
+        print('Warming activity banner images')
+        succeeded, failed = create_activity_banner_image_warmer(
+            Activity.objects.filter(~Q(banner_image='')),
+            verbose=True,
+        ).warm()
+        print('succeeded', succeeded, 'failed', len(failed))
+
+        print('Warming offer images')
+        succeeded, failed = create_offer_image_warmer(
+            OfferImage.objects.all(),
+            verbose=True,
+        ).warm()
+        print('succeeded', succeeded, 'failed', len(failed))
+
+        print('Warming conversation message images')
+        succeeded, failed = create_conversation_message_image_warmer(
+            ConversationMessageImage.objects.all(),
+            verbose=True,
+        ).warm()
+        print('succeeded', succeeded, 'failed', len(failed))

--- a/karrot/offers/models.py
+++ b/karrot/offers/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models import IntegerField, DateTimeField
 from django.utils import timezone
 from versatileimagefield.fields import VersatileImageField
+from versatileimagefield.image_warmer import VersatileImageFieldWarmer
 
 from karrot.base.base_models import BaseModel
 from karrot.conversations.models import ConversationMixin
@@ -54,3 +55,12 @@ class OfferImage(BaseModel):
         null=False,
     )
     position = IntegerField(default=0)
+
+
+def create_offer_image_warmer(instance_or_queryset, *, verbose=False):
+    return VersatileImageFieldWarmer(
+        instance_or_queryset=instance_or_queryset,
+        rendition_key_set='offer_image',
+        image_attr='image',
+        verbose=verbose,
+    )

--- a/karrot/offers/receivers.py
+++ b/karrot/offers/receivers.py
@@ -2,7 +2,7 @@ from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
 from karrot.conversations.models import Conversation
-from karrot.offers.models import Offer, OfferImage
+from karrot.offers.models import Offer, OfferImage, create_offer_image_warmer
 from karrot.offers.tasks import notify_members_about_new_offer
 from karrot.utils.misc import on_transaction_commit
 
@@ -21,3 +21,8 @@ def offer_saved(sender, instance, created, **kwargs):
 def delete_offer_image_files(sender, instance, **kwargs):
     instance.image.delete_all_created_images()
     instance.image.delete(save=False)
+
+
+@receiver(post_save, sender=OfferImage)
+def warm_activity_banner_image(sender, instance, **kwargs):
+    create_offer_image_warmer(instance).warm()

--- a/karrot/userauth/models.py
+++ b/karrot/userauth/models.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db import models
 from django.db.models import CharField, ForeignKey
 from django.utils import crypto, timezone
+from versatileimagefield.image_warmer import VersatileImageFieldWarmer
 
 from karrot.base.base_models import BaseModel
 
@@ -57,3 +58,12 @@ class VerificationCode(BaseModel):
         True if the expiration date lies in the past.
         """
         return self.created_at + timedelta(seconds=self._get_validity_time_limit()) < timezone.now()
+
+
+def create_user_photo_warmer(instance_or_queryset, *, verbose=False):
+    return VersatileImageFieldWarmer(
+        instance_or_queryset=instance_or_queryset,
+        rendition_key_set='user_profile',
+        image_attr='photo',
+        verbose=verbose,
+    )

--- a/karrot/userauth/receivers.py
+++ b/karrot/userauth/receivers.py
@@ -1,8 +1,9 @@
-from django.contrib.auth import user_login_failed, user_logged_in
+from django.contrib.auth import user_login_failed, user_logged_in, get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from karrot.userauth import stats
+from karrot.userauth.models import create_user_photo_warmer
 from karrot.users.models import User
 
 
@@ -21,3 +22,9 @@ def user_post_save_handler(**kwargs):
     """Sends a metric to InfluxDB when a new User object is created."""
     if kwargs.get('created'):
         stats.user_created()
+
+
+@receiver(post_save, sender=get_user_model())
+def warm_user_photo(sender, instance, **kwargs):
+    if instance.photo:
+        create_user_photo_warmer(instance).warm()


### PR DESCRIPTION
It's a performance hog for some endpoints.

As recommended in https://django-versatileimagefield.readthedocs.io/en/latest/improving_performance.html

As part of https://github.com/karrot-dev/karrot-frontend/issues/2667