### PR TITLE
Extend session periodically

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -217,6 +217,7 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'karrot.utils.extend_session_middleware.ExtendSessionMiddleware',
 )
 
 ROOT_URLCONF = 'config.urls'

--- a/karrot/utils/extend_session_middleware.py
+++ b/karrot/utils/extend_session_middleware.py
@@ -1,0 +1,34 @@
+import time
+from math import floor
+
+# how many seconds
+EXTEND_PERIOD = 3600
+
+
+class ExtendSessionMiddleware:
+    """ Extend the session expiry periodically
+
+    Django only saves the session when it's modified, the redis ttl is set
+    when it's saved. We tend not to modify the session, so users get logged
+    out after the session expiry duration (2 weeks default) even though they
+    were active.
+
+    There is the SESSION_SAVE_EVERY_REQUEST option, but we don't really need
+    it saved EVERY request.
+
+    So we have this middleground middleware :)
+
+    We store a unix timestamp of when we want to next extend in the session
+    and when we reach that time, set it again into the future.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.session:
+            now = floor(time.time())
+            extend_after = request.session.get('extend_after', None)
+            if extend_after is None or now > extend_after:
+                # the act of modifying it will cause it to save and reset the ttl
+                request.session['extend_after'] = now + EXTEND_PERIOD
+        return self.get_response(request)

--- a/scripts/psql
+++ b/scripts/psql
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+if ! podman pod exists karrot-services; then
+  echo "Services not running!"
+  echo
+  echo "You can run ./scripts/dev to start everything"
+  echo "Or ./scripts/services/start for just the services"
+  exit 1
+fi
+
+podman exec -it karrot-services-db psql -U db "$@"

--- a/scripts/redis-cli
+++ b/scripts/redis-cli
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+if ! podman pod exists karrot-services; then
+  echo "Services not running!"
+  echo
+  echo "You can run ./scripts/dev to start everything"
+  echo "Or ./scripts/services/start for just the services"
+  exit 1
+fi
+
+podman exec -it karrot-services-redis redis-cli "$@"


### PR DESCRIPTION
I noticed I get logged out from time to time, even though I'm actively using karrot, and it's annoying!

I found django only extends the session when you modify it, which we don't, after the initial creation, so it just runs to expiry (2 weeks).

There is a django option to save on every request, but that's a bit much, so I created a middleware to extend the session every hour, if you're still making requests to the site.