### PR TITLE
GPG encrypt exported archives

### DIFF
--- a/karrot/management/commands/export.py
+++ b/karrot/management/commands/export.py
@@ -1,16 +1,40 @@
+from textwrap import dedent
+
 from django.core.management import BaseCommand
+from django.utils.crypto import get_random_string
 
 from karrot.migrate.exporter import export_to_file
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument("--groups", help="group ids", required=True)
-        parser.add_argument("filename", nargs="?", default="export.tar.xz")
+        parser.add_argument("--groups", help="group ids, comma seperated", required=True)
+        parser.add_argument("filename", nargs="?", default="export.tar.xz.gpg")
 
     def handle(self, *args, **options):
         output_filename = options["filename"]
         group_ids = [int(group_id) for group_id in options["groups"].split(",")]
         print("Exporting to", output_filename)
-        export_to_file(group_ids, output_filename)
-        print("Export complete")
+
+        # generate a password for them, so we can ensure it's long/secure enough
+        password = get_random_string(60)
+
+        export_to_file(group_ids, output_filename, password)
+
+        print(
+            dedent(
+                f"""
+            Export complete
+
+            Your file has been encrypted with a passphrase.
+            You will need this password to import it again.
+
+            The password is:
+
+                {password}
+
+            Transfer the password and export file separately so if someone has the
+            file but not the password they will not be able to access the data.
+        """.strip("\n")
+            )
+        )

--- a/karrot/management/commands/import.py
+++ b/karrot/management/commands/import.py
@@ -1,3 +1,5 @@
+from getpass import getpass
+
 from django.contrib.auth.models import AnonymousUser
 from django.core.management import BaseCommand, call_command
 
@@ -15,7 +17,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         input_filename = options["filename"]
         print("Importing", input_filename)
-        import_from_file(input_filename)
+        password = getpass("Password: ") if input_filename.endswith(".gpg") else None
+        import_from_file(input_filename, password)
         call_command("flush_sized_images_cache")
         call_command("warm_images")
         print("Import complete")

--- a/requirements.in
+++ b/requirements.in
@@ -59,6 +59,7 @@ urllib3<2 # sentry-sdk does not support urllib3 yet: https://github.com/getsentr
 pywebpush
 typing_extensions
 livekit-api
+python-gnupg
 
 # dev PyPI dependencies
 pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -145,6 +145,7 @@ pytest-django==4.7.0
 pytest-xdist==3.4.0
 python-dateutil==2.8.2
 python-dotenv==1.0.0
+python-gnupg==0.5.2
 python-magic==0.4.27
 pytz==2023.3.post1
 pywebpush==1.14.0


### PR DESCRIPTION
I am always uncomfortable when imaging how exported files of user data might be handled, so it feels responsible to GPG encrypt them with a strong password.

As it's a one-off export/import I made it using symmetric encryption mode (using `AES256`), and it generates a 60 character random password (passphrase...).

The idea is the person would transfer the file somehow, and transfer the password via a different means so they are not together, then the exported archive file is not readable by anyone without the password.

Default export filename is `export.tar.xz.gpg` and you can unpack the archive using standard tools, e.g.:

```
mkdir /tmp/unpacked
gpg -d export.tar.xz.gpg | tar -xJf - -C /tmp/unpacked
```

The tests cover the whole export/encryption/import, so all is good!