### PR TITLE
Fix slow database queries

### DIFF
--- a/karrot/activities/api.py
+++ b/karrot/activities/api.py
@@ -343,7 +343,10 @@ class ActivityViewSet(
         if self.action in ("retrieve", "list"):
             # because we have participants field in the serializer
             # only prefetch on read_only actions, otherwise there are caching problems when participants get added
-            qs = qs.select_related("activity_type").prefetch_related(
+            qs = qs.select_related(
+                "activity_type",
+                "series",
+            ).prefetch_related(
                 "activityparticipant_set",
                 "feedback_set",
                 "participant_types",

--- a/karrot/stats/api.py
+++ b/karrot/stats/api.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db.models import Count, F, OuterRef, Q, Subquery, Sum, Value
+from django.db.models import F, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce, Concat
 from django_filters import IsoDateTimeFromToRangeFilter
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet, ModelChoiceFilter, ModelMultipleChoiceFilter
@@ -16,6 +16,7 @@ from karrot.history.models import History, HistoryTypus
 from karrot.places.models import Place
 from karrot.stats import stats
 from karrot.stats.serializers import ActivityHistoryStatsSerializer, FrontendStatsSerializer
+from karrot.utils.query_utils import NonAggregatingCount, NonAggregatingSum
 
 
 class StatsThrottle(UserRateThrottle):
@@ -32,24 +33,6 @@ def users_queryset(request):
 
 def activity_type_queryset(request):
     return ActivityType.objects.filter(group__in=request.user.groups.all())
-
-
-class NonAggregatingCount(Count):
-    """A COUNT that does not trigger a GROUP BY to be added
-
-    This is useful when using Subquery in an annotation
-    """
-
-    contains_aggregate = False
-
-
-class NonAggregatingSum(Sum):
-    """A SUM that does not trigger a GROUP BY to be added
-
-    This is useful when using Subquery in an annotation
-    """
-
-    contains_aggregate = False
 
 
 class ActivityHistoryStatsFilter(FilterSet):

--- a/karrot/utils/query_utils.py
+++ b/karrot/utils/query_utils.py
@@ -1,0 +1,19 @@
+from django.db.models import Count, Sum
+
+
+class NonAggregatingCount(Count):
+    """A COUNT that does not trigger a GROUP BY to be added
+
+    This is useful when using Subquery in an annotation
+    """
+
+    contains_aggregate = False
+
+
+class NonAggregatingSum(Sum):
+    """A SUM that does not trigger a GROUP BY to be added
+
+    This is useful when using Subquery in an annotation
+    """
+
+    contains_aggregate = False


### PR DESCRIPTION
Sentry kindly reported two issues with the activities list endpoint:
1. *an n+1 query* - this got added when I added public activity series, and the implementation pulls in the series banner for each activity, which is uses if the banner isn't set on the series. this is resolved by `select_related("series")`
2. *slow `with_free_slots` query* - this query is a bit of a beast, and wasn't written in the most optimal way, I rewrote it to use an exists subquery, and it should be much faster as it can reuse data from the outer query now 🤞