### PR TITLE
Support python 3.11

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,4 @@
 [tools]
-python = { version='3.9.17', virtualenv='env' }
+python = "3.11"
+[env]
+_.python.venv = "env"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Prerequisites:
   - install it via package manager or from https://podman.io
 
 ```commandline
-# if not using rtx, create a virtualenv and activate it
+# create a virtualenv
 python -m venv env
+
+# if not using mise, you'll need to activate the virtualenv
 source env/bin/activate
 
 # install deps

--- a/karrot/webhooks/utils.py
+++ b/karrot/webhooks/utils.py
@@ -3,11 +3,11 @@ from base64 import b32decode, b32encode
 
 import requests
 import sentry_sdk
-import talon
+import talon_core
 from anymail.exceptions import AnymailAPIError
 from django.conf import settings
 from django.core import signing
-from talon import quotations
+from talon_core import quotations
 
 from karrot.webhooks import stats
 from karrot.webhooks.emails import prepare_incoming_email_rejected_email
@@ -15,7 +15,7 @@ from karrot.webhooks.emails import prepare_incoming_email_rejected_email
 logger = logging.getLogger(__name__)
 
 # register talon xpath extensions, to avoid XPathEvalError
-talon.init()
+talon_core.init()
 
 
 def trim_with_talon(text):

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,11 @@
-# Removes machine learning dependencies
-# Zulip maintains their own fork:
-# https://github.com/zulip/zulip/blob/61e1e38a00f4ef9fe4c1a302b93ce059646c62a6/requirements/common.in#L60-L61
-# Might hopefully get merged eventually: https://github.com/mailgun/talon/pull/200
--e git+https://github.com/tiltec/talon@80886cd#egg=talon
+# We use Zulip's fork of talon for two reasons:
+#
+# 1. they remove machine learning dependencies
+#    https://github.com/mailgun/talon/pull/200
+#
+# 2. cchardet is now unmaintained and they switched to a fork
+#    https://github.com/zulip/talon/commit/5529af43ff5172ff30c1a7b99111a68dcd997810
+https://github.com/zulip/talon/archive/refs/tags/zulip-25522.zip#egg=talon-core&subdirectory=talon-core
 
 # Common PyPI dependencies
 django[argon2]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --no-annotate
 #
--e git+https://github.com/tiltec/talon@80886cd#egg=talon
 aiofiles==23.2.1
 aiohttp==3.9.0
 aiosignal==1.3.1
@@ -23,7 +22,6 @@ bleach==6.1.0
 bleach-allowlist==1.0.3
 boltons==23.1.1
 build==1.0.3
-cchardet==2.1.7
 certifi==2023.11.17
 cffi==1.16.0
 cfgv==3.4.0
@@ -64,6 +62,7 @@ executing==2.0.1
 face==20.1.1
 factory-boy==3.3.0
 faker==20.0.3
+faust-cchardet==2.1.19
 filelock==3.13.1
 fractional-indexing==0.1.3
 freezegun==1.2.2
@@ -97,6 +96,7 @@ iniconfig==2.0.0
 ipython==8.17.2
 jedi==0.19.1
 jinja2==3.1.2
+joblib==1.3.2
 jsonschema==4.20.0
 jsonschema-specifications==2023.11.1
 livekit-api==0.3.0
@@ -165,6 +165,7 @@ sniffio==1.3.0
 sqlparse==0.4.4
 stack-data==0.6.3
 starlette==0.32.0.post1
+talon-core @ https://github.com/zulip/talon/archive/refs/tags/zulip-25522.zip#subdirectory=talon-core
 tblib==3.0.0
 tomli==2.0.1
 traitlets==5.13.0


### PR DESCRIPTION
Was limited by cchardet dependency before

I switched the talon dependency from @tiltec's fork to the zulip fork, as in addition to not requiring the machine learning deps, it also fixes the cchardet dep issue. 